### PR TITLE
Fix Markdown task list in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,35 +26,27 @@ which will output the contents of:
 ## Current Status
 
 
-- [x] Store files in `~/.h-files`` 
+- [x] Store files in `~/.h-files` 
 
-- [x] Show a file if an argument with the same name
-is passed (e.g. `h whatever`` displays 
-`~/.h-files/whatever.txt``)
+- [x] Show a file if an argument with the same name is passed (e.g. `h whatever` displays `~/.h-files/whatever.txt`)
 
-- [x] List out all files if the `h`` command is
-run with no arguments
+- [x] List out all files if the `h` command is run with no arguments
 
-- [x] make the ~/.h-files directory if it doesn't 
-already exist
+- [x] make the ~/.h-files directory if it doesn't already exist
 
 - [ ] Sort direcotry listing of existing files
 
-- [ ] Setup `--edit whatever` to open the file in 
-the default editor
+- [ ] Setup `--edit whatever` to open the file in the default editor
 
 - [ ] Setup `--new whatever` to make new files
 
 - [ ] Setup `--delete whatever` to remove files
 
-- [ ] Set the spacer lines equal to the longest
-line of text or the width of the terminal 
-(whichever is shortest)
+- [ ] Set the spacer lines equal to the longest line of text or the width of the terminal (whichever is shortest)
 
 - [ ] Autocomplete file names from in the arguments 
 
-- [ ] Allow for typing in numbers to open a file
-based on the order of the listing
+- [ ] Allow for typing in numbers to open a file based on the order of the listing
 
 
 ## Installation
@@ -68,5 +60,4 @@ adding it to your path so you can use it:
 ```
 cargo install --path .
 ```
-
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ which will output the contents of:
 
 - [x] make the ~/.h-files directory if it doesn't already exist
 
-- [ ] Sort direcotry listing of existing files
+- [ ] Sort directory listing of existing files
 
 - [ ] Setup `--edit whatever` to open the file in the default editor
 

--- a/README.md
+++ b/README.md
@@ -26,34 +26,34 @@ which will output the contents of:
 ## Current Status
 
 
-[x] Store files in `~/.h-files`` 
+- [x] Store files in `~/.h-files`` 
 
-[x] Show a file if an argument with the same name
+- [x] Show a file if an argument with the same name
 is passed (e.g. `h whatever`` displays 
 `~/.h-files/whatever.txt``)
 
-[x] List out all files if the `h`` command is
+- [x] List out all files if the `h`` command is
 run with no arguments
 
-[x] make the ~/.h-files directory if it doesn't 
+- [x] make the ~/.h-files directory if it doesn't 
 already exist
 
-[] Sort direcotry listing of existing files
+- [ ] Sort direcotry listing of existing files
 
-[] Setup `--edit whatever` to open the file in 
+- [ ] Setup `--edit whatever` to open the file in 
 the default editor
 
-[] Setup `--new whatever` to make new files
+- [ ] Setup `--new whatever` to make new files
 
-[] Setup `--delete whatever` to remove files
+- [ ] Setup `--delete whatever` to remove files
 
-[] Set the spacer lines equal to the longest
+- [ ] Set the spacer lines equal to the longest
 line of text or the width of the terminal 
 (whichever is shortest)
 
-[] Autocomplete file names from in the arguments 
+- [ ] Autocomplete file names from in the arguments 
 
-[] Allow for typing in numbers to open a file
+- [ ] Allow for typing in numbers to open a file
 based on the order of the listing
 
 


### PR DESCRIPTION
Before the task list was not properly shown in Github.

This PR fixes it.

Also fixed a bunch of backticks (`) and a typo.

~seven